### PR TITLE
Zim title search

### DIFF
--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -115,13 +115,13 @@ define(['zimfile', 'zimDirEntry', 'util'],
                 return prefix < dirEntry.title ? -1 : 1;
             });
         }, true).then(function(firstIndex) {
-            //@todo do not add titles that do not have the right prefix
             var titles = [];
             var addTitles = function(index) {
                 if (index >= firstIndex + resultSize || index >= that._file.articleCount)
                     return titles;
                 return that._file.dirEntryByTitleIndex(index).then(function(dirEntry) {
-                    titles.push(that._dirEntryToTitleObject(dirEntry));
+                    if (dirEntry.title.slice(0, prefix.length) == prefix)
+                        titles.push(that._dirEntryToTitleObject(dirEntry));
                     return addTitles(index + 1);
                 });
             };

--- a/www/js/lib/zimArchive.js
+++ b/www/js/lib/zimArchive.js
@@ -110,6 +110,8 @@ define(['zimfile', 'zimDirEntry', 'util'],
         var that = this;
         util.binarySearch(0, this._file.articleCount, function(i) {
             return that._file.dirEntryByTitleIndex(i).then(function(dirEntry) {
+                if (dirEntry.title == "")
+                    return -1; // ZIM sorts empty titles (assets) to the end
                 return prefix < dirEntry.title ? -1 : 1;
             });
         }, true).then(function(firstIndex) {


### PR DESCRIPTION
Fixed a bug about titles not being found because ZIM sorts empty titles to the end (this includes all auxiliary files like images).
Furthermore, added the check whether the search prefix is actually a prefix of the title.

Fixes #122
Fixes #104